### PR TITLE
Feature/net logger

### DIFF
--- a/app/test_led.py
+++ b/app/test_led.py
@@ -1,13 +1,13 @@
 from m5stack import *
 from m5ui import *
 from uiflow import *
-from my_utils import Log, my_init
+from my_utils import Logger, my_init
 
-my_init(0, lcd.FONT_DefaultSmall, 0, 0)
+my_init()
 
 led_status = False
 
-log = Log()
+log = Logger()
 
 
 def A_press():

--- a/app/test_log.py
+++ b/app/test_log.py
@@ -1,21 +1,17 @@
 from m5stack import *
 from m5ui import *
 from uiflow import *
-from my_utils import Log, my_init
+from my_utils import Logger, my_init
 from random import randint
 
-my_init(3, lcd.FONT_DefaultSmall, 0, 0)
+my_init(rotation=1)
 
-log = Log()
-
-lcd.println(log.max_len_per_line)
-lcd.println(log.max_line)
+log = Logger(ezdata_token="3lpzokiWbY4LzE61mraLIF5fsMV5Ja4m")
 
 
 def btn_a_press():
-    t = ""
-    for i in range(randint(1, 20)):
-        t += str(randint(1, 10))
+    num = randint(1, 30)
+    t = str(num + len(str(num))) + chr(randint(65, 90)) * num
     log.log(t)
 
 

--- a/utils/my_utils.py
+++ b/utils/my_utils.py
@@ -1,41 +1,67 @@
-from typing import List
 from m5stack import lcd, rtc
+from flow import ezdata
 import wifiCfg
 
 
-class Log():
-    def __init__(self) -> None:
+def date_format(date):
+    return "%04d-%02d-%02d %02d:%02d:%02d" % date
+
+
+class Logger():
+    def __init__(
+        self,
+        ezdata_token: str = "",
+        up_to_ezdata: bool = True,
+        print_to_screen: bool = True,
+        log_name: str = "log_" + date_format(rtc.now())
+    ) -> None:
+        self.loglist: List[str] = []
+        self.logtime: List[list] = []
+
+        self.up_to_ezdata = up_to_ezdata
+        self.__ezdata_token = ezdata_token
+        self.log_name = log_name
+
+        self.print_to_screen = print_to_screen
         self.win_width, self.win_height = lcd.winsize()
         self.font_width, self.font_height = lcd.fontSize()
-
-        self.max_len_per_line = self.win_width // self.font_width - 1
-        self.max_line = self.win_height // self.font_height - 1
-
-        self.loglist: List[str] = []
         self.print_loglist: List[str] = []
-        lcd.clear()
+
+        self.log("start log.....")
 
     def log(self, text: str) -> None:
         self.loglist.append(text)
-        self.print_loglist.append(text)
-        self.__print_log()
+        self.logtime.append(rtc.now())
+
+        if self.up_to_ezdata and self.__ezdata_token:
+            self.__upload(-1)
+
+        if self.print_to_screen:
+            self.print_loglist.append(text)
+            self.__print_log()
+
+    def __upload(self, index):
+        text = date_format(self.logtime[index]) + " " + self.loglist[index]
+        ezdata.addToList(self.__ezdata_token, self.log_name, text)
 
     def clear(self) -> None:
-        lcd.clear()
         self.print_loglist = []
-        lcd.print("", 0, 0)
+        if self.print_to_screen:
+            lcd.clear()
+            lcd.print("", 0, 0)
 
     def __print_log(self):
-        print_list = self.print_loglist[-self.max_line:]
 
         lcd.clear()
-        lcd.print("", 0, 0)
-        for text in print_list:
-            if len(text) <= self.max_len_per_line:
-                lcd.println(text)
-            else:
-                a = text[:self.max_len_per_line]
-                lcd.println(a)
+        y = self.win_height - 1
+        for text in self.print_loglist[::-1]:
+            line_offset = lcd.textWidth(text) // self.win_width + 1
+            y = y - self.font_height * line_offset
+
+            if y <= 0:
+                return
+
+            lcd.print(text, 0, y)
 
 
 def sync_jp_localtime_with_ntp():
@@ -52,13 +78,15 @@ def sync_jp_localtime_with_ntp():
     rtc.setTime(t[0], t[1], t[2], t[3], t[4], t[5])
 
 
-def date_format(date):
-    return "%04d-%02d-%02d %02d:%02d:%02d" % date
-
-
 def my_init(
     rotation=0, font=lcd.FONT_DefaultSmall, print_pox=0, print_poy=0, wifilcdShow=True
 ):
+    """
+    rotation：画面の向き(0,1,2,3)、
+    print_pox：printの最初の座標
+    print_poy：printの最初の座標
+    wifilcdShow：wifi接続画面を表示するかどうか
+    """
     wifiCfg.autoConnect(lcdShow=wifilcdShow)
     sync_jp_localtime_with_ntp()
 


### PR DESCRIPTION
ezdataにlogをuploadすることは実装した
ここから(<https://ezdata.m5stack.com/debugger/>)確認することができる

`up_to_ezdata = True`でuploadを有効化するが、logの記録は少し遅い
原因はmicropythonの非同期処理はちょいめんどでuasyncioのスケジューラを使うが、M5StickCのmicropythonのバージョンが古くてuasyncioがない可能性もあったりして......